### PR TITLE
Add 'view workflow link' button

### DIFF
--- a/src/message-card.ts
+++ b/src/message-card.ts
@@ -43,6 +43,12 @@ export function createMessageCard(
     potentialAction: [
       {
         '@context': 'http://schema.org',
+        target: [`${repoUrl}/actions/runs/${runId}`],
+        '@type': 'ViewAction',
+        name: 'View Workflow Run'
+      },
+      {
+        '@context': 'http://schema.org',
         target: [commit.data.html_url],
         '@type': 'ViewAction',
         name: 'View Commit Changes'


### PR DESCRIPTION
Adding the `View Workflow Run` button at the end of the alert message, as available in the [original marketplace action](https://github.com/jdcargile/ms-teams-notification/blob/master/src/message-card.ts#L37-L42)

<img width="911" alt="image" src="https://user-images.githubusercontent.com/18636680/156781422-63727564-b848-49dc-8e2c-990c094c4a91.png">
